### PR TITLE
ACF 8 Error - Extension Loader

### DIFF
--- a/corefiles/fuseboxExtensionManager.cfc
+++ b/corefiles/fuseboxExtensionManager.cfc
@@ -17,6 +17,7 @@
 		<cfset var fbExtensions = "" />
 		<cfset var extHolder = "" />
 		<cfset var loadCount = 0 />
+		<cfset var theMetaData = "" />
 		<cfif NOT directoryExists(arguments.path)>
 			<cfthrow type="fusebox.BadDirectory" message="Directory does not exist." detail="Yourn path is probably wrong: #path#" />
 		</cfif>
@@ -24,7 +25,8 @@
 		<cfloop query="fbExtensions">
 			<cfif fbExtensions.type EQ "file">				
 				<cfset extHolder = createObject("component", pathUtil.locateCfc("#fbExtensions.directory#/#fbExtensions.name#")).init(variables.fbXml) />
-				<cfif addExtension(extHolder, getMetaData(extHolder)["fusebox:lifecycle"])>
+				<cfset theMetaData = getMetaData(extHolder)>
+				<cfif addExtension(extHolder, theMetaData["fusebox:lifecycle"])>
 					<cfset loadCount = loadCount + 1 />
 				</cfif>
 			</cfif>


### PR DESCRIPTION
ACF 8 chokes on the extension loader unless you set the metadata to a variable and then use array notation rather than calling it directly.
