### PR TITLE
Resolve name conflict with Railo/Lucee BIF getCanonicalPath

### DIFF
--- a/corefiles/PathUtil.cfc
+++ b/corefiles/PathUtil.cfc
@@ -10,7 +10,7 @@
 		<cfargument name="callerPath" type="string" required="true" 
 						hint="I am FUSEBOX_CALLER_PATH." />
 	
-		<cfset variables.approotdirectory = getCanonicalPath(normalizePartialPath(arguments.callerPath) & normalizePartialPath(arguments.appPath)) />
+		<cfset variables.approotdirectory = this.getCanonicalPath(normalizePartialPath(arguments.callerPath) & normalizePartialPath(arguments.appPath)) />
 		<cfset calculatePaths(variables.approotdirectory) />
 		<cfreturn this />
 	</cffunction>
@@ -134,8 +134,8 @@
 					hint="I deduce the dot-separated path to a CFC given its file system path (and a few heuristics).">
 			<cfargument name="filename" type="string" required="true" />
 		
-			<cfset var cfcPath = getCanonicalPath(filename) />
-			<cfset var webRoot = getCanonicalPath(expandPath("/")) />
+			<cfset var cfcPath = this.getCanonicalPath(filename) />
+			<cfset var webRoot = this.getCanonicalPath(expandPath("/")) />
 			<cfset var lenWebRoot = len(webRoot) />
 			<cfset var lenAppRoot = len(getApplicationRoot()) />
 			<cfset var lenCfcPath = len(cfcPath) />


### PR DESCRIPTION
The issue arises from the naming conflict of the getCanonicalPath() method with Railo/Lucee's built in function of that same name.

See https://groups.google.com/d/msg/lucee/4_LL03OC5T0/yCV1Hw31ewMJ

TBH I didn't test this patch (I don't have Fusebox installed anywhere and don't have the time to install it ATM), but it looks like it should do the trick.
