### PR TITLE
Fixes for use with CF2018 and forward

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-time-machine

--- a/corefiles/PathUtil.cfc
+++ b/corefiles/PathUtil.cfc
@@ -10,7 +10,7 @@
 		<cfargument name="callerPath" type="string" required="true" 
 						hint="I am FUSEBOX_CALLER_PATH." />
 	
-		<cfset variables.approotdirectory = getCanonicalPath(normalizePartialPath(arguments.callerPath) & normalizePartialPath(arguments.appPath)) />
+		<cfset variables.approotdirectory = getFBCanonicalPath(normalizePartialPath(arguments.callerPath) & normalizePartialPath(arguments.appPath)) />
 		<cfset calculatePaths(variables.approotdirectory) />
 		<cfreturn this />
 	</cffunction>
@@ -60,7 +60,7 @@
 		
 	</cffunction>
 	
-	<cffunction name="getCanonicalPath" returntype="string" access="public" output="false" 
+	<cffunction name="getFBCanonicalPath" returntype="string" access="public" output="false" 
 				hint="I return a canonical file path (with all /../ sections resolved).">
 		<cfargument name="path" type="string" required="true" 
 					hint="I am the path to resolve." />
@@ -134,8 +134,8 @@
 					hint="I deduce the dot-separated path to a CFC given its file system path (and a few heuristics).">
 			<cfargument name="filename" type="string" required="true" />
 		
-			<cfset var cfcPath = getCanonicalPath(filename) />
-			<cfset var webRoot = getCanonicalPath(expandPath("/")) />
+			<cfset var cfcPath = getFBCanonicalPath(filename) />
+			<cfset var webRoot = getFBCanonicalPath(expandPath("/")) />
 			<cfset var lenWebRoot = len(webRoot) />
 			<cfset var lenAppRoot = len(getApplicationRoot()) />
 			<cfset var lenCfcPath = len(cfcPath) />

--- a/corefiles/fuseboxApplication.cfc
+++ b/corefiles/fuseboxApplication.cfc
@@ -1291,12 +1291,12 @@ limitations under the License.
 		
 	</cffunction>
 	
-	<cffunction name="getCanonicalPath" returntype="string" access="public" output="false" 
+	<cffunction name="getFBCanonicalPath" returntype="string" access="public" output="false" 
 				hint="I return a canonical file path (with all /../ sections resolved).">
 		<cfargument name="path" type="string" required="true" 
 					hint="I am the path to resolve." />
 					
-		<cfreturn pathUtil.getCanonicalPath(arguments.path) />
+		<cfreturn pathUtil.getFBCanonicalPath(arguments.path) />
 		
 	</cffunction>
 	

--- a/corefiles/fuseboxCircuit.cfc
+++ b/corefiles/fuseboxCircuit.cfc
@@ -70,7 +70,7 @@ limitations under the License.
 			</cfif>
 		</cfif>
 		
-		<cfset variables.fullPath = variables.fuseboxApplication.getCanonicalPath(variables.fullPath) />
+		<cfset variables.fullPath = variables.fuseboxApplication.getFBCanonicalPath(variables.fullPath) />
 
 		<!---
 			this was not correctly normalized prior to ticket 139 but it didn't really matter

--- a/corefiles/fuseboxPlugin.cfc
+++ b/corefiles/fuseboxPlugin.cfc
@@ -110,7 +110,7 @@ limitations under the License.
 														this.path,arguments.fbApp.getApplicationRoot()) />
 			</cfif>
 			
-			<cfset this.rootpath = arguments.fbApp.getCanonicalPath(this.rootpath) />
+			<cfset this.rootpath = arguments.fbApp.getFBCanonicalPath(this.rootpath) />
 			
 			<cfset variables.parameters = arguments.pluginXML.xmlChildren />
 			<cfset variables.paramVerbs = structNew() />


### PR DESCRIPTION
Much like Railo/Lucee - CF2018 has its own getCanonicalPath function.
I have renamed the FuseBox function to "getFBCanonicalPath"